### PR TITLE
refactor and fix code style

### DIFF
--- a/Controller/FacebookController.php
+++ b/Controller/FacebookController.php
@@ -387,11 +387,11 @@ class FacebookController extends Controller
             } else {
                 // We are done with configuring the locations, so lets end the Wizard and persist the locations.
                 // TODO: Wrap into DB transaction.
-                $repository = $this->getDoctrine()->getManager();
+                $em = $this->getDoctrine()->getManager();
 
                 foreach($locations as $identifier => $location){
                     // Persist the Facebook user- and page-specific data.
-                    $repository->persist($wizard->get($identifier));
+                    $em->persist($wizard->get($identifier));
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -414,14 +414,14 @@ class FacebookController extends Controller
                     if(
                         isset($locations[$identifier])
                     ){
-                        $token = $repository->merge($token);
+                        $token = $em->merge($token);
                         $token->setLocation($locations[$identifier]);
                         $tokenService->setToken($token);
                     }
                 }
 
                 $wizard->end();
-                $repository->flush();
+                $em->flush();
 
                 return $this->redirect($this->generateUrl('campaignchain_core_channel'));
             }


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
